### PR TITLE
Don't be too aggresive with -- filter

### DIFF
--- a/src/dotnet-mono/Program.fs
+++ b/src/dotnet-mono/Program.fs
@@ -163,7 +163,7 @@ module Main =
         let additionalArgs =
             args
             |> Array.skipWhile(fun x -> x <> "--")
-            |> Array.filter(fun x -> x <> "--")
+            |> (fun a -> if Array.tryHead a = Some "--" then Array.tail a else a)
         argus,additionalArgs
 
     let main' argv = trial {


### PR DESCRIPTION
As mentioned in https://github.com/TheAngryByrd/dotnet-mono/pull/35#discussion_r172403145 the original code could filter out additional -- which running exe might rely on

Closes #36 