### PR TITLE
Fixes unhandled process access exception

### DIFF
--- a/src/dotnet-mono/Program.fs
+++ b/src/dotnet-mono/Program.fs
@@ -204,9 +204,12 @@ module Main =
 
         setupCloseSignalers ()
 
-        Message.eventX "dotnet-mono current process id: {id}" LogLevel.Info
-        |> Message.setField "id" (Process.GetCurrentProcess()).Id
-        |> logger.logSync
+        try
+            Message.eventX "dotnet-mono current process id: {id}" LogLevel.Info
+            |> Message.setField "id" (Process.GetCurrentProcess()).Id
+            |> logger.logSync
+        with
+        | _ -> ()
 
         let! project = 
             match results.TryGetResult <@ Project @> with


### PR DESCRIPTION
Adds a do-nothing handler for cases where mono fails to
access the current process in a Linux environment